### PR TITLE
PraosModel: Fix `lhs2tex` invocation and change to SVG 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
           ];
           # other inputs needed (typically to allow cabal to work properly)
           nativeBuildInputs = [
+            pkgs.svg2pdf
             pkgs.zlib
             (pkgs.texlive.combine {
               inherit (pkgs.texlive)

--- a/src/performance/.gitignore
+++ b/src/performance/.gitignore
@@ -10,4 +10,5 @@
 *.bbl
 *.blg
 *.md
+*.svg
 dist-newstyle

--- a/src/performance/app/Main.hs
+++ b/src/performance/app/Main.hs
@@ -1,20 +1,28 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Main where
+
+import Data.Default.Class
 import PraosModel
 import Graphics.Rendering.Chart
-import Graphics.Rendering.Chart.Backend.Cairo
+import Graphics.Rendering.Chart.Backend.Diagrams
+import System.Process
 
 main :: IO ()
 main = do 
-    let myOptions = FileOptions (400,400) PDF
-    _ <- renderableToFile myOptions "app/Inserts/oneHopDelays.pdf" (toRenderable oneHopCDF)
-    _ <- renderableToFile myOptions "app/Inserts/multi-hop64k-plots.pdf" (toRenderable multiHopCDF64k)
-    _ <- renderableToFile myOptions "app/Inserts/multi-hop-1024k-plots.pdf" (toRenderable multiHopCDF1024k)
-    _ <- renderableToFile myOptions "app/Inserts/blended-hop-blocksizes.pdf" (toRenderable blendedHopCDFNode10)
-    _ <- renderableToFile myOptions "app/Inserts/verified-hop-blocksizes.pdf" (toRenderable blendedHopCDFNode10')
-    _ <- renderableToFile myOptions "app/Inserts/pipelined-hop-script.pdf" (toRenderable pipelindedMultiHopScript)
-    _ <- renderableToFile myOptions "app/Inserts/pipelined-hop-value.pdf" (toRenderable pipelindedMultiHopValue)
-    _ <- renderableToFile myOptions "app/Inserts/pipelined-hop-bounding.pdf" (toRenderable pipelindedMultiHopBounding)
-    _ <- renderableToFile myOptions "app/Inserts/compared-hop-blocktypes.pdf" (toRenderable comparedCDFNode10)
-
+    renderableToPDF "app/Inserts/oneHopDelays" (toRenderable oneHopCDF)
+    renderableToPDF "app/Inserts/multi-hop64k-plots" (toRenderable multiHopCDF64k)
+    renderableToPDF "app/Inserts/multi-hop-1024k-plots" (toRenderable multiHopCDF1024k)
+    renderableToPDF "app/Inserts/blended-hop-blocksizes" (toRenderable blendedHopCDFNode10)
+    renderableToPDF "app/Inserts/verified-hop-blocksizes" (toRenderable blendedHopCDFNode10')
+    renderableToPDF "app/Inserts/pipelined-hop-script" (toRenderable pipelindedMultiHopScript)
+    renderableToPDF "app/Inserts/pipelined-hop-value" (toRenderable pipelindedMultiHopValue)
+    renderableToPDF "app/Inserts/pipelined-hop-bounding" (toRenderable pipelindedMultiHopBounding)
+    renderableToPDF "app/Inserts/compared-hop-blocktypes" (toRenderable comparedCDFNode10)
     putStrLn "All done"
+
+renderableToPDF :: FilePath -> Renderable () -> IO ()
+renderableToPDF filename renderable = do
+    _ <- renderableToFile myOptions (filename <> ".svg") renderable
+    callProcess "svg2pdf" [filename <> ".svg", filename <> ".pdf"]
+  where
+    myOptions = def { _fo_size = (400,400), _fo_format = SVG }

--- a/src/performance/app/PraosModel.lhs
+++ b/src/performance/app/PraosModel.lhs
@@ -386,10 +386,10 @@ forkProbability f slotTime d = 1 - probNoFork f slotTime d
             successWithin d'' (fromIntegral (i' - 1) * s')
 \end{code}
 where $f$ is the active slot fraction, and $d$ is the \dq{} for the transfer delay.
-%Thus, for instance, the probability of a fork in a network of 2500 nodes of degree 10, with
-%a block size of 64kB, and active slot fraction of $0.01$ and a slot time of 2s, is 
-%options ghci -fglasgow-exts
-%\eval{(fromRational . forkProbability 0.02 2 (blendedDelayNode10 B64)) :: Double}.
+Thus, for instance, the probability of a fork in a network of 2500 nodes of degree 10, with
+a block size of 64kB, and active slot fraction of $0.01$ and a slot time of 2s, is 
+%options ghci
+\eval{fromRational (forkProbability 0.02 2 (blendedDelayNode10 B64)) :: Double}.
 
 \subsection{Verification Before Forwarding}
 So far, we have only considered the time taken to transfer a block from one node to another.

--- a/src/performance/cabal.project
+++ b/src/performance/cabal.project
@@ -1,0 +1,5 @@
+packages:
+  .
+
+write-ghc-environment-files:
+  always

--- a/src/performance/praos1.cabal
+++ b/src/performance/praos1.cabal
@@ -71,9 +71,11 @@ executable praos1
 
     -- Other library packages from which modules are imported.
     build-depends:    base >=4.17.2.0,
+                      data-default-class >= 0.1.2,
                       deltaq >= 1.0.0.0,
                       Chart >= 1.9.5,
-                      Chart-cairo >= 1.9.4
+                      Chart-diagrams >= 1.9.4,
+                      process >= 1.6
 
     -- Directories containing source files.
     hs-source-dirs:   app


### PR DESCRIPTION
This pull request changes `PraosModel` such that

* The use of `\eval` now works thanks to a GHC environment file
* The PDF files are generated from SVG for better compatibility with macOS

Following the steps in `src/performance/README.md` should produce the desired result.