### PR TITLE
Handle zero-hop paths in pipelined Praos model

### DIFF
--- a/src/performance/app/PraosModel.lhs
+++ b/src/performance/app/PraosModel.lhs
@@ -639,17 +639,23 @@ using recursion for both the header propagation and the block body transfers:
 \begin{code}
 passHeader :: Int -> BlockContents -> DQ -- pass the header along a path of length n
 passHeader n b
+| n <= 0 = wait 0
+  | n == 1 = validateHeader b
+  | otherwise = doSequentially [validateHeader b, announceBlock b, passHeader (n - 1) b]
   | n == 1 = validateHeader b
   | otherwise = doSequentially [validateHeader b, announceBlock b, passHeader (n - 1) b]
 
 getBlock :: Int -> BlockContents -> DQ  -- pass the block along a path of length n
 -- we must first receive the header before we can request the block from nodes that 
 -- have already received the header and may have the block body
-getBlock n b = doSequentially [forgeBlock b, announceBlock b, passHeader n b, 
-                               requestBlock b, goGetBlock n b]
+getBlock n b
+  | n <= 0 = wait 0
+  | otherwise = doSequentially [forgeBlock b, announceBlock b, passHeader n b, 
+                                requestBlock b, goGetBlock n b]
   where
     goGetBlock :: Int -> BlockContents -> DQ 
     goGetBlock n b
+      | n <= 0 = wait 0
       | n == 1 = doSequentially [transferBlock b, checkBlock b, adoptBlock b]
       | otherwise = 
         transferBlock b .>>. ((checkBlock b ./\. requestBlock b) .>>. goGetBlock (n - 1) b)
@@ -806,7 +812,6 @@ probNoLeader :: Rational -- active slot fraction
              -> Rational -- probability of no leader
 probNoLeader f m = (1 - f) ^ m
 \end{code}
-
 
 \bibliographystyle{plain}
 \bibliography{Inserts/DeltaQBibliography,Inserts/AdditionalEntries}


### PR DESCRIPTION
Motivation
Prevent runaway recursion and undefined behaviour when pipelined helpers are called with zero or negative hop counts by returning a safe zero-delay outcome instead of recursing.
Description
Added guards to passHeader, getBlock, and the local goGetBlock so that n <= 0 returns wait 0 to handle invalid or zero-length paths in src/performance/app/PraosModel.lhs.
Testing
No automated tests were run for this change.